### PR TITLE
Add setter for RedisSettings

### DIFF
--- a/goworker.go
+++ b/goworker.go
@@ -42,6 +42,10 @@ func SetSettings(settings WorkerSettings) {
 	workerSettings = settings
 }
 
+func SetRedisSettings(redisSettings RedisSettings) {
+	workerSettings.RedisSettings = redisSettings
+}
+
 type RedisSettings struct {
 	URI        string
 	Host       string


### PR DESCRIPTION
The exposed `RedisSettings` can currently be only set as a part of `WorkerSettings` which is incredibly annoying - when I want to configure goworker to use Sentinel, I don't want to have to redefine which queues to work on, what namespace to use etc., this is already parsed from flags. Without the proposed function, the only choice is to parse the flags again and recreate the same struct + my Redis config.

The proposed function allows me to set only this one field on the unexported struct.